### PR TITLE
allow null setting for domain

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ internals.schema = Joi.object({
     cookie: Joi.string().default('sid'),
     password: Joi.string().required(),
     ttl: Joi.number().integer().min(0).when('keepAlive', { is: true, then: Joi.required() }),
-    domain: Joi.string(),
+    domain: Joi.string().allow(null),
     path: Joi.string().default('/'),
     clearInvalid: Joi.boolean().default(false),
     keepAlive: Joi.boolean().default(false),
@@ -57,7 +57,7 @@ internals.implementation = function (server, options) {
         cookieOptions.ttl = settings.ttl;
     }
 
-    if (settings.domain) {
+    if (settings.hasOwnProperty('domain')) {
         cookieOptions.domain = settings.domain;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ internals.implementation = function (server, options) {
         cookieOptions.ttl = settings.ttl;
     }
 
-    if (settings.hasOwnProperty('domain')) {
+    if (settings.domain) {
         cookieOptions.domain = settings.domain;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ internals.schema = Joi.object({
     keepAlive: Joi.boolean().default(false),
     isSecure: Joi.boolean().default(true),
     isHttpOnly: Joi.boolean().default(true),
-    redirectTo: Joi.string(),
+    redirectTo: Joi.string().allow(false),
     appendNext: Joi.boolean().default(false),
     redirectOnTry: Joi.boolean().default(true),
     validateFunc: Joi.func()

--- a/test/index.js
+++ b/test/index.js
@@ -1291,7 +1291,6 @@ describe('scheme', function () {
 
         it('skips when redirectTo is set to false', function (done) {
 
-
             var server = new Hapi.Server();
             server.connection();
             server.register(require('../'), function (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -1289,6 +1289,39 @@ describe('scheme', function () {
             });
         });
 
+        it('skips when redirectTo is set to false', function (done) {
+
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.register(require('../'), function (err) {
+
+                expect(err).to.not.exist();
+
+                server.auth.strategy('default', 'cookie', true, {
+                    password: 'password',
+                    ttl: 60 * 1000,
+                    redirectTo: false,
+                    appendNext: true
+                });
+
+                server.route({
+                    method: 'GET',
+                    path: '/',
+                    handler: function (request, reply) {
+
+                        return reply('never');
+                    }
+                });
+
+                server.inject('/', function (res) {
+
+                    expect(res.statusCode).to.equal(401);
+                    done();
+                });
+            });
+        });
+
         it('skips when route override', function (done) {
 
             var server = new Hapi.Server();


### PR DESCRIPTION
Per #64 allows domains to be set to `null` an allowed value for `server.state`.