### PR TITLE
validateFunc according to signature function

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -87,7 +87,7 @@ server.register(require('../'), function (err) {
         cookie: 'sid-example',
         redirectTo: '/login',
         isSecure: false,
-        validateFunc: function (session, callback) {
+        validateFunc: function (request, session, callback) {
 
             cache.get(session.sid, function (err, cached) {
 


### PR DESCRIPTION
fixes `TypeError: Uncaught error: callback is not a function` when
posting correct password and name.