### PR TITLE
Error: Uncaught error: No active session to apply key to

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ internals.implementation = function (server, options) {
                 if (arguments.length > 1) {
                     var key = session;
                     Hoek.assert(key && typeof key === 'string', 'Invalid session key');
-                    session = request.auth.artifacts;
+                    session = request.auth.artifacts || request.auth.credentials;
                     Hoek.assert(session, 'No active session to apply key to');
 
                     session[key] = value;
@@ -90,7 +90,7 @@ internals.implementation = function (server, options) {
 
                 if (arguments.length) {
                     Hoek.assert(key && typeof key === 'string', 'Invalid session key');
-                    var session = request.auth.artifacts;
+                    var session = request.auth.artifacts || request.auth.credentials;
                     Hoek.assert(session, 'No active session to clear key from');
                     delete session[key];
                     return reply.state(settings.cookie, session);
@@ -101,7 +101,7 @@ internals.implementation = function (server, options) {
             },
             ttl: function (msecs) {
 
-                var session = request.auth.artifacts;
+                var session = request.auth.artifacts || request.auth.credentials;
                 Hoek.assert(session, 'No active session to modify ttl on');
                 reply.state(settings.cookie, session, { ttl: msecs });
             }


### PR DESCRIPTION
auth.artifacts is optional for Hapi, but hapi-auth-cookie was requiring it; causing an error when multiple strategies were employed and artifacts was empty.This change just expands the check for a session to include checking for auth.credentials (which is required for an authenticated session).