### PR TITLE
Fix incorrect description of `validateFunc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ takes the following required options:
         - `err` - an internal error.
         - `isValid` - `true` if the content of the session is valid, otherwise `false`.
         - `credentials` - a credentials object passed back to the application in
-          `request.auth.credentials`. If value is `null` or `undefined`, defaults to `session`. If
-          set, will override the current cookie as if `request.cookieAuth.set()` was called.
+          `request.auth.credentials`. If value is `null` or `undefined`, defaults to `session`.
 
 When the cookie scheme is enabled on a route, the `request.cookieAuth` objects is decorated with
 the following methods:


### PR DESCRIPTION
It stated that the third parameter of callback would overwrite the cookie, [but that’s not true](https://github.com/hapijs/hapi-auth-cookie/blob/654c299a0b0048e8d2f4787f1fbc60ef84692518/lib/index.js#L155-L171).