### PR TITLE
update readme with information/warning about cookie length

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@
 
 Lead Maintainer: [James Weston](https://github.com/jaw187)
 
-Cookie authentication provides a simple cookie-based session management. The user has to be
-authenticated via other means, typically a web form, and upon successful authentication,
-receive a reply with a session cookie. Subsequent requests containing the session cookie are
-authenticated (the cookie uses [Iron](https://github.com/hueniverse/iron) to encrypt and sign the
-session content) and validated via the provided `validateFunc` in case the cookie's encrypted
-content requires validation on each request. Note that cookie operates as a bearer token and anyone
-in possession of the cookie content can use it to impersonate its true owner. The `'cookie`' scheme
-takes the following required options:
+Cookie authentication provides simple cookie-based session management. The user has to be
+authenticated via other means, typically a web form, and upon successful authentication
+the browser receives a reply with a session cookie. The cookie uses [Iron](https://github.com/hueniverse/iron) to encrypt and sign the session content.
+
+Subsequent requests containing the session cookie are authenticated and validated via the provided `validateFunc` in case the cookie's encrypted content requires validation on each request.
+
+It is important to remember a couple of things:
+
+1. Cookies have a practical maximum length. All of the data you store in a cookie is sent to the browser. If your cookie is too long, browsers may not set it. Read more [here](http://webdesign.about.com/od/cookies/f/web-cookies-size-limit.htm) and [here](http://www.ietf.org/rfc/rfc2965.txt). If you need need to store more data, store a small amount of identifying data in the cookie and use that as a key to a server-side cache system.
+2. Each cookie operates as a bearer token and anyone in possession of the cookie content can use it to impersonate its true owner. 
+
+The `'cookie`' scheme takes the following required options:
 
 - `cookie` - the cookie name. Defaults to `'sid'`.
 - `password` - used for Iron cookie encoding. Should be at least 32 characters long.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Subsequent requests containing the session cookie are authenticated and validate
 
 It is important to remember a couple of things:
 
-1. Cookies have a practical maximum length. All of the data you store in a cookie is sent to the browser. If your cookie is too long, browsers may not set it. Read more [here](http://webdesign.about.com/od/cookies/f/web-cookies-size-limit.htm) and [here](http://www.ietf.org/rfc/rfc2965.txt). If you need need to store more data, store a small amount of identifying data in the cookie and use that as a key to a server-side cache system.
-2. Each cookie operates as a bearer token and anyone in possession of the cookie content can use it to impersonate its true owner. 
+1. Each cookie operates as a bearer token and anyone in possession of the cookie content can use it to impersonate its true owner. 
+2. Cookies have a practical maximum length. All of the data you store in a cookie is sent to the browser. If your cookie is too long, browsers may not set it. Read more [here](http://webdesign.about.com/od/cookies/f/web-cookies-size-limit.htm) and [here](http://www.ietf.org/rfc/rfc2965.txt). If you need need to store more data, store a small amount of identifying data in the cookie and use that as a key to a server-side cache system.
 
 The `'cookie`' scheme takes the following required options:
 


### PR DESCRIPTION
Updated README opening.

- Added information about cookie lengths and if they are too long, they don't get set. 
- Adjusted formatting of text in the opening paragraph to be a little easier to read.

I got bit by this today when I spent an hour wondering why my session cookies weren't being set. When I last opened my project, bell + hapi-auth-cookie was signing into Twitter with no problem. But today it was mysteriously failing at first. It finally clicked that the cookie length was way too long. The credential data Twitter was returning a few days ago was a smaller size than today (I may made some last minute change and forgot about it), and that's why it was failing.

Since it wasn't documented in the README already, I figure its just a nice thing to remind people about in case they run into a similar problem in the future.