### PR TITLE
Allow null to be passed for the ttl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ exports.register.attributes = {
 internals.schema = Joi.object({
     cookie: Joi.string().default('sid'),
     password: Joi.alternatives(Joi.string(), Joi.object().type(Buffer)).required(),
-    ttl: Joi.number().integer().min(0).when('keepAlive', { is: true, then: Joi.required() }),
+    ttl: Joi.number().integer().min(0).allow(null).when('keepAlive', { is: true, then: Joi.required() }),
     domain: Joi.string().allow(null),
     path: Joi.string().default('/'),
     clearInvalid: Joi.boolean().default(false),


### PR DESCRIPTION
`null` is a valid default option for the `ttl` of the cookie but the schema isn't currently allowing it.

As an example, in our case the value for `ttl` is coming from an external place; from a configuration system which sets it on a per-env basis.
In test/development the `ttl` might be set to an explicit value whereas in production it might be `null` 

```js
        server.auth.strategy('session', 'cookie', 'try', {
            password: options.cookieOptions.password,
            cookie: 'ssosid',
            ttl: options.cookieOptions.ttl,
            domain: options.cookieOptions.domain,
            redirectOnTry: false,
            appendNext: true,
            clearInvalid: true,
            isSecure: true,
            isHttpOnly: true,
            validateFunc: validate
        });
```

We can work around this easily by doing something like:
```js
        const strategyOptions = {
            password: options.cookieOptions.password,
            cookie: 'ssosid',
            domain: options.cookieOptions.domain,
            redirectOnTry: false,
            appendNext: true,
            clearInvalid: true,
            isSecure: true,
            isHttpOnly: true,
            validateFunc: validate
        };

        if(options.cookieOptions.ttl) {
            strategyOptions.ttl = options.cookieOptions.ttl;
        }

        server.auth.strategy('session', 'cookie', 'try', strategyOptions);
```

However, it just felt a little cleaner to have the `ttl` schema accept a valid cookie ttl value.

Thoughts?