### PR TITLE
update the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is important to remember a couple of things:
 1. Each cookie operates as a bearer token and anyone in possession of the cookie content can use it to impersonate its true owner.
 2. Cookies have a practical maximum length. All of the data you store in a cookie is sent to the browser. If your cookie is too long, browsers may not set it. Read more [here](http://webdesign.about.com/od/cookies/f/web-cookies-size-limit.htm) and [here](http://www.ietf.org/rfc/rfc2965.txt). If you need to store more data, store a small amount of identifying data in the cookie and use that as a key to a server-side cache system.
 
-The `'cookie`' scheme takes the following required options:
+The `'cookie'` scheme takes the following required options:
 
 - `cookie` - the cookie name. Defaults to `'sid'`.
 - `password` - used for Iron cookie encoding. Should be at least 32 characters long.

--- a/example/index.js
+++ b/example/index.js
@@ -14,11 +14,20 @@ const users = {
 
 const home = function (request, reply) {
 
-    reply('<html><head><title>Login page</title></head><body><h3>Welcome ' +
-      request.auth.credentials.name +
-      '!</h3><br/><form method="get" action="/logout">' +
-      '<input type="submit" value="Logout">' +
-      '</form></body></html>');
+    // This is a private page; if the authentication fails (missing cookie for instance),
+    // the response will be a 302 redirection to the path given in 'redirectTo' and the
+    // handler is not executed at all
+    console.log('credentials: ', request.auth.credentials);
+    const html = `
+        <html>
+            <head><title>Private content page</title></head>
+            <body>
+                <h3>Welcome ${ request.auth.credentials.name }!</h3>
+                <a href="/logout">Logout (clear the cookie)</a>
+            </body>
+        </html>
+    `;
+    return reply(html);
 };
 
 const login = function (request, reply) {
@@ -27,37 +36,54 @@ const login = function (request, reply) {
         return reply.redirect('/');
     }
 
-    let message = '';
+    const html = `
+        <html>
+            <head><title>Login page</title></head>
+            <body>
+                <form method="post" action="/login">
+                    Username: <input type="text" name="username"><br/>
+                    Password: <input type="password" name="password"><br/>
+                    <input type="submit" value="Login">
+                </form>
+            </body>
+        </html>
+    `;
+    return reply(html);
+};
+
+const loginData = function (request, reply) {
+
+    if (request.auth.isAuthenticated) {
+        return reply.redirect('/');
+    }
+
+    let errorMessage = '';
     let account = null;
 
-    if (request.method === 'post') {
-
-        if (!request.payload.username ||
-            !request.payload.password) {
-
-            message = 'Missing username or password';
-        }
-        else {
-            account = users[request.payload.username];
-            if (!account ||
-                account.password !== request.payload.password) {
-
-                message = 'Invalid username or password';
-            }
+    if (!request.payload.username || !request.payload.password) {
+        errorMessage = 'Missing username or password';
+    }
+    else {
+        account = users[request.payload.username];
+        if (!account || account.password !== request.payload.password) {
+            errorMessage = 'Invalid username or password';
         }
     }
 
-    if (request.method === 'get' ||
-        message) {
-
-        return reply('<html><head><title>Login page</title></head><body>' +
-            (message ? '<h3>' + message + '</h3><br/>' : '') +
-            '<form method="post" action="/login">' +
-            'Username: <input type="text" name="username"><br>' +
-            'Password: <input type="password" name="password"><br/>' +
-            '<input type="submit" value="Login"></form></body></html>');
+    if(errorMessage){
+        const html = `
+            <html>
+                <head><title>Login error</title></head>
+                <body>
+                    <h3>${ errorMessage }</h3>
+                    <a href="/login">Click here</a> to try again.
+                </body>
+            </html>
+        `;
+        return reply(html);
     }
 
+    // store the account object (credentials) in the cache and send the cookie with the uuid
     const sid = String(++uuid);
     request.server.app.cache.set(sid, { account: account }, 0, (err) => {
 
@@ -73,7 +99,7 @@ const login = function (request, reply) {
 const logout = function (request, reply) {
 
     request.cookieAuth.clear();
-    return reply.redirect('/');
+    return reply.redirect('/login');
 };
 
 const server = new Hapi.Server();
@@ -85,10 +111,11 @@ server.register(require('../'), (err) => {
         throw err;
     }
 
+    // set up a catbox policy (catbox-memory is used by default)
     const cache = server.cache({ segment: 'sessions', expiresIn: 3 * 24 * 60 * 60 * 1000 });
     server.app.cache = cache;
 
-    server.auth.strategy('session', 'cookie', true, {
+    server.auth.strategy('session', 'cookie', {
         password: 'password-should-be-32-characters',
         cookie: 'sid-example',
         redirectTo: '/login',
@@ -98,26 +125,76 @@ server.register(require('../'), (err) => {
             cache.get(session.sid, (err, cached) => {
 
                 if (err) {
-                    return callback(err, false);
+                    return callback(err);
                 }
 
+                // we pass false in the 2nd argument so in the handler we'll have
+                // request.auth.isAuthenticated === false
                 if (!cached) {
                     return callback(null, false);
                 }
 
+                // the cached object will be available in the handler at request.auth.credentials
                 return callback(null, true, cached.account);
             });
         }
     });
 
     server.route([
-        { method: 'GET', path: '/', config: { handler: home } },
-        { method: ['GET', 'POST'], path: '/login', config: { handler: login, auth: { mode: 'try' }, plugins: { 'hapi-auth-cookie': { redirectTo: false } } } },
-        { method: 'GET', path: '/logout', config: { handler: logout } }
+        {
+            method: 'GET',
+            path: '/',
+            config: {
+                handler: home,
+                auth: {
+                    strategy: 'session',
+                    mode: 'required'
+                }
+            }
+        },
+        {
+            method: 'GET',
+            path: '/login',
+            config: {
+                handler: login,
+                auth: {
+                    strategy: 'session',
+                    mode: 'try'
+                },
+                plugins: {
+                    'hapi-auth-cookie': {
+                        redirectTo: false
+                    }
+                }
+            }
+        },
+        {
+            method: 'POST',
+            path: '/login',
+            config: {
+                handler: loginData,
+                auth: {
+                    strategy: 'session',
+                    mode: 'try'
+                },
+                plugins: {
+                    'hapi-auth-cookie': {
+                        redirectTo: false
+                    }
+                }
+            }
+        },
+        {
+            method: 'GET',
+            path: '/logout',
+            config: {
+                handler: logout
+            }
+        }
     ]);
 
     server.start(() => {
 
-        console.log('Server ready');
+        console.log('Server running at:', server.info.uri);
     });
 });

--- a/example/index.js
+++ b/example/index.js
@@ -70,7 +70,7 @@ const loginData = function (request, reply) {
         }
     }
 
-    if(errorMessage){
+    if (errorMessage){
         const html = `
             <html>
                 <head><title>Login error</title></head>


### PR DESCRIPTION
- use template literals for better legibility of the html 
- in the html of the private page, instead of `<form action="/logout">` use a simple `<a href="/logout">`
- extract the '/login' route into 2 separate routes: one just to handle the form data, the other just to show the login form
- in the call to `server.auth.strategy`, remove the 3rd arg ("assign as the default strategy to routes without an 'auth' config") - this removes removes any magic from the example
- make the route configuration more easy to read (properties on separate lines)

If these changes are accepted i can send a new pull request to update the example in the readme (copy-paste).
