### PR TITLE
referenced the raw request when setting next

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ The `'cookie`' scheme takes the following options:
   redirect, voiding `'try'` mode. To set an individual route to use or disable redirections, use
   the route `plugins` config (`{ config: { plugins: { 'hapi-auth-cookie': { redirectTo: false } } } }`).
   Defaults to no redirection.
-- `appendNext` - if `true` and `redirectTo` is `true`, appends the current request path to the
-  query component of the `redirectTo` URI using the parameter name `'next'`. Set to a string to use
-  a different parameter name. Defaults to `false`.
+- `appendNext` - if `redirectTo` is `true`, can be a boolean, string, or object. Defaults to `false`.
+    - if set to `true`, a string, or an object, appends the current request path to the query component
+      of the `redirectTo` URI
+    - set to a string value or set the `name` property in an object to define the parameter name.
+      defaults to `'next'`
+    - set the `raw` property of the object to `true` to determine the current request path based on
+      the raw node.js request object received from the HTTP server callback instead of the processed
+      hapi request object
 - `redirectOnTry` - if `false` and route authentication mode is `'try'`, authentication errors will
   not trigger a redirection. Requires **hapi** version 6.2.0 or newer. Defaults to `true`;
 - `validateFunc` - an optional session validation function used to validate the content of the

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ internals.schema = Joi.object({
     isSecure: Joi.boolean().default(true),
     isHttpOnly: Joi.boolean().default(true),
     redirectTo: Joi.alternatives(Joi.string(), Joi.func()).allow(false),
-    appendNext: Joi.alternatives(Joi.string(), Joi.boolean()).default(false),
+    appendNext: Joi.alternatives(Joi.string(), Joi.boolean(), Joi.object({ raw: Joi.boolean(), name: Joi.string() })).default(false),
     redirectOnTry: Joi.boolean().default(true),
     validateFunc: Joi.func(),
     requestDecoratorName: Joi.string().default('cookieAuth'),
@@ -69,6 +69,11 @@ internals.implementation = function (server, options) {
 
     if (typeof settings.appendNext === 'boolean') {
         settings.appendNext = (settings.appendNext ? 'next' : '');
+    }
+
+    if (typeof settings.appendNext === 'object') {
+        settings.appendNextRaw = settings.appendNext.raw;
+        settings.appendNext = settings.appendNext.name || 'next';
     }
 
     server.state(settings.cookie, cookieOptions);
@@ -210,7 +215,12 @@ internals.implementation = function (server, options) {
                         uri += '?';
                     }
 
-                    uri += settings.appendNext + '=' + encodeURIComponent(request.url.path);
+                    if (settings.appendNextRaw) {
+                        uri += settings.appendNext + '=' + encodeURIComponent(request.raw.req.url);
+                    }
+                    else {
+                        uri += settings.appendNext + '=' + encodeURIComponent(request.url.path);
+                    }
                 }
 
                 return reply('You are being redirected...', null, result).redirect(uri);


### PR DESCRIPTION
this would be a breaking change for anyone that uses `setUrl()`, but does not want the original request to be where `next` is directed. i struggle to think of such a case, but you likely have better insight.

resolves #150

