### PR TITLE
Do not redecorate the request object if already decorated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please view our [hapijs contributing guide](https://github.com/hapijs/hapi/blob/master/CONTRIBUTING.md).
+Please view our [hapijs contributing guide](https://github.com/hapijs/hapi/blob/master/.github/CONTRIBUTING.md).

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ internals.implementation = function (server, options) {
 
     // Check if the request object should be decorated
     const decorations = server.root._requestor._decorations || {};
-    const isDecorated = Object.keys(decorations).includes(settings.requestDecoratorName);
+    const isDecorated = decorations[settings.requestDecoratorName];
 
     if (!settings.ignoreIfDecorated || !isDecorated) {
         server.decorate('request', settings.requestDecoratorName, decoration, { apply: true });

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ internals.schema = Joi.object({
     appendNext: Joi.alternatives(Joi.string(), Joi.boolean()).default(false),
     redirectOnTry: Joi.boolean().default(true),
     validateFunc: Joi.func(),
-    requestDecoratorName: Joi.string().default('cookieAuth')
+    requestDecoratorName: Joi.string().default('cookieAuth'),
+    ignoreIfDecorated: Joi.boolean().default(true)
 }).required();
 
 internals.implementation = function (server, options) {
@@ -123,7 +124,13 @@ internals.implementation = function (server, options) {
         return new CookieAuth();
     };
 
-    server.decorate('request', settings.requestDecoratorName, decoration, { apply: true });
+    // Check if the request object should be decorated
+    const decorations = server.root._requestor._decorations || {};
+    const isDecorated = Object.keys(decorations).includes(settings.requestDecoratorName);
+
+    if (!settings.ignoreIfDecorated || !isDecorated) {
+        server.decorate('request', settings.requestDecoratorName, decoration, { apply: true });
+    }
 
     server.ext('onPreAuth', (request, reply) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -855,6 +855,30 @@ describe('scheme', () => {
         });
     });
 
+    it('errors if ignoreIfDecorated is false and the request object is already decorated', (done) => {
+
+        const password = 'password-should-be-32-characters';
+        const ignoreIfDecorated = false;
+        const options = { password, ignoreIfDecorated };
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register(require('../'), (err) => {
+
+            expect(err).to.not.exist();
+
+            server.auth.strategy('default', 'cookie', true, options);
+
+            expect(err).to.not.exist();
+            expect(() => {
+
+                server.auth.strategy('default', 'cookie', true, options);
+            }).to.throw(Error);
+
+            done();
+        });
+    });
+
     describe('set()', () => {
 
         it('errors on missing session in set()', (done) => {


### PR DESCRIPTION
I have a separate PR opened against Hapi to allow for someone to check if a request object is already decorated with a method.  However, that should only affect people using HapiJS 16.0.X.  This PR can be used with previous versions of Hapi, as the underlying logic is still there.

This addresses https://github.com/hapijs/hapi-auth-cookie/issues/119
