### PR TITLE
Issue 163

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -171,7 +171,7 @@ internals.implementation = function (server, options) {
                             reply.unstate(settings.cookie);
                         }
 
-                        return unauthenticated(Boom.unauthorized('Invalid cookie'), { credentials: credentials || session, artifacts: session });
+                        return unauthenticated(err || Boom.unauthorized('Invalid cookie'), { credentials: credentials || session, artifacts: session });
                     }
 
                     if (settings.keepAlive) {

--- a/test/index.js
+++ b/test/index.js
@@ -421,6 +421,7 @@ describe('scheme', () => {
             ttl: 60 * 1000,
             cookie: 'first',
             validateFunc: function (request, session) {
+
                 throw Boom.unauthorized(null, 'first');
             }
         });

--- a/test/index.js
+++ b/test/index.js
@@ -458,14 +458,13 @@ describe('scheme', () => {
         expect(header[0]).to.contain('Max-Age=60');
         const cookie = header[0].match(/(?:[^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)\s*=\s*(?:([^\x00-\x20\"\,\;\\\x7F]*))/);
 
-        server.inject({ method: 'GET', url: '/resource', headers: { cookie: 'first=' + cookie[1] } }, (res2) => {
+        const res2 = await server.inject({ method: 'GET', url: '/resource', headers: { cookie: 'first=' + cookie[1] } });
 
-            expect(res2.statusCode).to.equal(200);
-            expect(res2.headers['set-cookie']).to.not.exist();
-            expect(res2.result).to.equal('valid-resource');
-            expect(res2.request.auth.isAuthenticated).to.be.true();
-            expect(res2.request.auth.credentials.user).to.equal('bogus-user');
-        });
+        expect(res2.statusCode).to.equal(200);
+        expect(res2.headers['set-cookie']).to.not.exist();
+        expect(res2.result).to.equal('valid-resource');
+        expect(res2.request.auth.isAuthenticated).to.be.true();
+        expect(res2.request.auth.credentials.user).to.equal('bogus-user');
     });
 
     it('authenticates a request (no ttl)', async () => {


### PR DESCRIPTION
Addresses https://github.com/hapijs/hapi-auth-cookie/issues/163

Allow fail-over to secondary auth strategy when validateFunc returns special Boom.unauthorized.

Refer to the Hapi docs:
https://hapijs.com/api#serverauthschemename-scheme

" If the err does not include a message but does include the scheme name (e.g. Boom.unauthorized(null, 'Custom')), additional strategies will be attempted in the order of preference (defined in the route configuration). "