### PR TITLE
Fix redirectTo function w/ blank to behave like blank redirectTo (fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `'cookie`' scheme takes the following options:
 - `isSecure` - if `false`, the cookie is allowed to be transmitted over insecure connections which
   exposes it to attacks. Defaults to `true`.
 - `isHttpOnly` - if `false`, the cookie will not include the 'HttpOnly' flag. Defaults to `true`.
-- `redirectTo` - optional login URI to redirect unauthenticated requests to. Note that using
+- `redirectTo` - optional login URI or function `function(request)` that returns a URI to redirect unauthenticated requests to. Note that using
   `redirectTo` with authentication mode `'try'` will cause the protected endpoint to always
   redirect, voiding `'try'` mode. To set an individual route to use or disable redirections, use
   the route `plugins` config (`{ options: { plugins: { 'hapi-auth-cookie': { redirectTo: false } } } }`).

--- a/lib/index.js
+++ b/lib/index.js
@@ -209,11 +209,12 @@ internals.implementation = (server, options) => {
                     redirectTo = request.route.settings.plugins['hapi-auth-cookie'].redirectTo;
                 }
 
-                if (!redirectTo) {
+                let uri = (typeof (redirectTo) === 'function') ? redirectTo(request) : redirectTo;
+
+                if (!uri) {
                     return h.unauthenticated(err);
                 }
 
-                let uri = (typeof (redirectTo) === 'function') ? redirectTo(request) : redirectTo;
                 if (settings.appendNext) {
                     if (uri.indexOf('?') !== -1) {
                         uri += '&';

--- a/test/index.js
+++ b/test/index.js
@@ -1106,6 +1106,33 @@ describe('scheme', () => {
             expect(res.statusCode).to.equal(401);
         });
 
+        it('skips when redirectTo is set to function that returns falsey value', async () => {
+
+            const server = Hapi.server();
+            await server.register(require('../'));
+
+            server.auth.strategy('default', 'cookie', {
+                password: 'password-should-be-32-characters',
+                ttl: 60 * 1000,
+                redirectTo: () => false,
+                appendNext: true
+            });
+            server.auth.default('default');
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, h) {
+
+                    return h.response('never');
+                }
+            });
+
+            const res = await server.inject('/');
+
+            expect(res.statusCode).to.equal(401);
+        });
+
         it('skips when route override', async () => {
 
             const server = Hapi.server();


### PR DESCRIPTION
Fixing #169 pull request. I destroyed it.

Currently when `redirectTo` is a function and the function returns blank, hapi-auth-cookie stills tries to do the redirect instead of behaving like `redirectTo: undefined`. Fixing this will allow issues like #144 where you might want different behavior on an API call vs the browser.

This change will allow something like following code to redirect or not according to a header set

```js
redirectTo (request) {
  const requestedWith = request.headers['x-requested-with'] && request.headers['x-requested-with'].toLowerCase()
  if (requestedWith && (requestedWith === 'ajax' || requestedWith === 'xmlhttprequest')) {
    return undefined
  } else {
    return '/login'
  }
}
```