### PR TITLE
Added an option to configure the encoding of the cookie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The `'cookie`' scheme takes the following options:
 - `isSecure` - if `false`, the cookie is allowed to be transmitted over insecure connections which
   exposes it to attacks. Defaults to `true`.
 - `isHttpOnly` - if `false`, the cookie will not include the 'HttpOnly' flag. Defaults to `true`.
+- `encoding` - How the cookie will be encoded. This is passed to the encoding option of [server.state(..)](https://hapijs.com/api#-serverstatename-options). Defaults to `iron`, which causes the cookie to be encrypted and signed.
 - `redirectTo` - optional login URI or function `function(request)` that returns a URI to redirect unauthenticated requests to. Note that it will only
   trigger when the authentication mode is `'required'`. To enable or disable redirections for a specific route,
   set the route `plugins` config (`{ options: { plugins: { 'hapi-auth-cookie': { redirectTo: false } } } }`).
@@ -57,10 +58,10 @@ The `'cookie`' scheme takes the following options:
 When the cookie scheme is enabled on a route, the `request.cookieAuth` objects is decorated with
 the following methods:
 - `set(session)` - sets the current session. Must be called after a successful login to begin the
-  session. `session` must be a non-null object, which is set on successful subsequent
+  session. `session` must be truthy, it will be set on successful subsequent
   authentications in `request.auth.credentials` where:
-    - `session` - the session object.
-- `set(key, value)` - sets a specific object key on the current session (which must already exist)
+    - `session` - the session.
+- `set(key, value)` - sets a specific object key on the current session (which must be an object and must already exist).
   where:
     - `key` - session key string.
     - `value` - value to assign key.

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ internals.schema = Joi.object({
     isSameSite: Joi.valid('Strict', 'Lax').allow(false).default('Strict'),
     isSecure: Joi.boolean().default(true),
     isHttpOnly: Joi.boolean().default(true),
+    encoding: Joi.string().default('iron'),
     redirectTo: Joi.alternatives(Joi.string(), Joi.func()).allow(false),
     appendNext: Joi.alternatives(Joi.string(), Joi.boolean()).default(false),
     validateFunc: Joi.func(),
@@ -54,12 +55,13 @@ internals.CookieAuth = class {
             Hoek.assert(key && typeof key === 'string', 'Invalid session key');
             session = request.auth.artifacts;
             Hoek.assert(session, 'No active session to apply key to');
+            Hoek.assert(typeof session === 'object',
+                'Session is not a object and thus does not support setting keys');
 
             session[key] = value;
             return h.state(settings.cookie, session);
         }
-
-        Hoek.assert(session && typeof session === 'object', 'Invalid session');
+        Hoek.assert(session, 'Invalid session');
         request.auth.artifacts = session;
         h.state(settings.cookie, session);
     }
@@ -97,7 +99,7 @@ internals.implementation = (server, options) => {
     const settings = results.value;
 
     const cookieOptions = {
-        encoding: 'iron',
+        encoding: settings.encoding,
         password: settings.password,
         isSecure: settings.isSecure,                  // Defaults to true
         path: settings.path,


### PR DESCRIPTION
It is useful to set the encoding to `none` when the cookie contains no information, for example when it is merely a cache key. Doing so reduces the length of each request. 

Relates to https://github.com/hapijs/hapi-auth-cookie/issues/198

Actions taken
- Added `encoding` to the settings schema
- Passed `encoding` to `server.state(..)`
- removed validation enforcing typeof session === 'object'
- added validation enforcing typeof session === 'object' when setting new session keys
- updated the readme